### PR TITLE
Extend code generation with struct & enum support

### DIFF
--- a/ast/array.go
+++ b/ast/array.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"fmt"
+
 	"github.com/HannesKimara/cddlc/token"
 )
 
@@ -18,4 +20,10 @@ func (a *Array) End() token.Position {
 		return token.Position{Offset: -1}
 	}
 	return a.Rules[len(a.Rules)-1].End()
+}
+
+func (a *Array) String() string {
+	s := fmt.Sprintf("%s - %s", a.Start(), a.End())
+
+	return s
 }

--- a/ast/bad_node.go
+++ b/ast/bad_node.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // BadNode represents a node formed due to  parsing error
 type BadNode struct {
@@ -25,4 +29,10 @@ func (b *BadNode) Start() token.Position {
 // End returns the estimated end of the bad node
 func (b *BadNode) End() token.Position {
 	return b.EndPos
+}
+
+func (b *BadNode) String() string {
+	s := fmt.Sprintf("%s - %s", b.Start(), b.End())
+
+	return s
 }

--- a/ast/boolean.go
+++ b/ast/boolean.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // BooleanType represents the AST Node for the `bool` type definition token.
 type BooleanType struct {
@@ -16,6 +20,12 @@ func (b *BooleanType) End() token.Position {
 	return b.Pos.To(4)
 }
 
+func (b *BooleanType) String() string {
+	s := fmt.Sprintf("%s - %s", b.Start(), b.End())
+
+	return s
+}
+
 type BooleanLiteral struct {
 	Range token.PositionRange
 	Bool  bool
@@ -27,4 +37,10 @@ func (bl *BooleanLiteral) Start() token.Position {
 
 func (bl *BooleanLiteral) End() token.Position {
 	return bl.Range.End
+}
+
+func (bl *BooleanLiteral) String() string {
+	s := fmt.Sprintf("%s - %s", bl.Start(), bl.End())
+
+	return s
 }

--- a/ast/bytes.go
+++ b/ast/bytes.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // BstrType represents the AST Node for the `bstr` type definition token.
 type BstrType struct {
@@ -22,10 +26,22 @@ func (b *BytesType) End() token.Position {
 	return b.Pos.To(5) // length of `bytes`
 }
 
+func (b *BytesType) String() string {
+	s := fmt.Sprintf("%s - %s", b.Start(), b.End())
+
+	return s
+}
+
 func (b *BstrType) Start() token.Position {
 	return b.Pos
 }
 
 func (b *BstrType) End() token.Position {
 	return b.Pos.To(5) // length of `bytes`
+}
+
+func (b *BstrType) String() string {
+	s := fmt.Sprintf("%s - %s", b.Start(), b.End())
+
+	return s
 }

--- a/ast/cddl_root.go
+++ b/ast/cddl_root.go
@@ -15,7 +15,7 @@ type CDDL struct {
 func (c *CDDL) String() string {
 	out := "CDDL ("
 	for _, rule := range c.Rules {
-		out += fmt.Sprintf("%+v,", rule)
+		out += fmt.Sprintf("%T %+v,\n", rule, rule)
 	}
 	out += ")"
 	return out

--- a/ast/comment.go
+++ b/ast/comment.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"fmt"
+
 	"github.com/HannesKimara/cddlc/token"
 )
 
@@ -16,6 +18,12 @@ func (c *Comment) Start() token.Position {
 
 func (c *Comment) End() token.Position {
 	return c.Pos.To(len(c.Text))
+}
+
+func (c *Comment) String() string {
+	s := fmt.Sprintf("%s - %s", c.Start(), c.End())
+
+	return s
 }
 
 func (c *Comment) cddlEntry()  {}

--- a/ast/control_bits.go
+++ b/ast/control_bits.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Bits represents the AST Node for `.bits` control operator
 type Bits struct {
@@ -23,4 +27,10 @@ func (r *Bits) Start() token.Position {
 
 func (r *Bits) End() token.Position {
 	return r.Contstraint.End()
+}
+
+func (r *Bits) String() string {
+	s := fmt.Sprintf("%s - %s", r.Start(), r.End())
+
+	return s
 }

--- a/ast/control_comparator.go
+++ b/ast/control_comparator.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // ControlOpControl represents the AST Node for operators `.lt, .le, .gt, .ge, .eq, .ne` with numeric left and right values.
 // This also takes identifiers that resolve to numeric types.
@@ -19,4 +23,10 @@ func (cc *ComparatorOpControl) Start() token.Position {
 
 func (cc *ComparatorOpControl) End() token.Position {
 	return cc.Right.End()
+}
+
+func (cc *ComparatorOpControl) String() string {
+	s := fmt.Sprintf("%s - %s", cc.Start(), cc.End())
+
+	return s
 }

--- a/ast/control_regexp.go
+++ b/ast/control_regexp.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Regexp represents the AST Node for `.regexp` control operator
 type Regexp struct {
@@ -16,4 +20,10 @@ func (r *Regexp) Start() token.Position {
 
 func (r *Regexp) End() token.Position {
 	return r.Regex.End()
+}
+
+func (r *Regexp) String() string {
+	s := fmt.Sprintf("%s - %s", r.Start(), r.End())
+
+	return s
 }

--- a/ast/control_size.go
+++ b/ast/control_size.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // SizeOperatorControl represents the AST Node for `.size` control operator
 type SizeOperatorControl struct {
@@ -25,4 +29,10 @@ func (sc *SizeOperatorControl) Start() token.Position {
 // End returns the end of the size
 func (sc *SizeOperatorControl) End() token.Position {
 	return sc.Size.End()
+}
+
+func (sc *SizeOperatorControl) String() string {
+	s := fmt.Sprintf("%s - %s", sc.Start(), sc.End())
+
+	return s
 }

--- a/ast/entry.go
+++ b/ast/entry.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Entry represents the Node for a group entry
 // It maps the name of the type to the type
@@ -17,5 +21,9 @@ func (r *Entry) Start() token.Position {
 func (r *Entry) End() token.Position {
 	return r.Value.End()
 }
+func (r *Entry) String() string {
+	s := fmt.Sprintf("%s - %s", r.Start(), r.End())
 
+	return s
+}
 func (r *Entry) groupEntry() {}

--- a/ast/enumeration.go
+++ b/ast/enumeration.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type Enumeration struct {
 	Pos   token.Position
@@ -13,6 +17,11 @@ func (e *Enumeration) Start() token.Position {
 }
 func (e *Enumeration) End() token.Position {
 	return e.Value.End()
+}
+func (e *Enumeration) String() string {
+	s := fmt.Sprintf("%s - %s", e.Start(), e.End())
+
+	return s
 }
 
 func (e *Enumeration) groupEntry() {}

--- a/ast/float.go
+++ b/ast/float.go
@@ -1,6 +1,8 @@
 package ast
 
 import (
+	"fmt"
+
 	"github.com/HannesKimara/cddlc/token"
 )
 
@@ -18,6 +20,11 @@ func (ft *FloatType) Start() token.Position {
 func (ft *FloatType) End() token.Position {
 	return ft.Pos.To(5) // TODO: support bases float64, 32, 16
 }
+func (ft *FloatType) String() string {
+	s := fmt.Sprintf("%s - %s", ft.Start(), ft.End())
+
+	return s
+}
 
 // FloatLiteral represesnts the AST Node for float type token i.e. 3.412
 type FloatLiteral struct {
@@ -32,4 +39,9 @@ func (fl *FloatLiteral) Start() token.Position {
 
 func (fl *FloatLiteral) End() token.Position {
 	return fl.Range.End
+}
+func (fl *FloatLiteral) String() string {
+	s := fmt.Sprintf("%s - %s", fl.Start(), fl.End())
+
+	return s
 }

--- a/ast/group.go
+++ b/ast/group.go
@@ -1,11 +1,23 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type GroupEntry interface {
 	Node
 	groupEntry() // convenience function
 }
+
+// TODO: set during parsing instead
+type GroupType uint
+
+const (
+	GroupTypeStruct = iota + 1
+	GroupTypeEnum
+)
 
 type Group struct {
 	Pos     token.Position
@@ -22,5 +34,9 @@ func (g *Group) End() token.Position {
 	}
 	return g.Entries[len(g.Entries)-1].End()
 }
+func (g *Group) String() string {
+	s := fmt.Sprintf("%s - %s", g.Start(), g.End())
 
+	return s
+}
 func (g *Group) groupEntry() {}

--- a/ast/groupchoice.go
+++ b/ast/groupchoice.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type GroupChoice struct {
 	Pos           token.Position
@@ -14,4 +18,10 @@ func (gc *GroupChoice) Start() token.Position {
 
 func (gc *GroupChoice) End() token.Position {
 	return gc.Second.End()
+}
+
+func (gc *GroupChoice) String() string {
+	s := fmt.Sprintf("%s - %s", gc.Start(), gc.End())
+
+	return s
 }

--- a/ast/integer.go
+++ b/ast/integer.go
@@ -20,6 +20,12 @@ func (it *IntegerType) End() token.Position {
 	return it.Pos.To(3) // length of `int`
 }
 
+func (it *IntegerType) String() string {
+	s := fmt.Sprintf("%s - %s", it.Start(), it.End())
+
+	return s
+}
+
 type NegativeIntegerType struct {
 	Pos   token.Position
 	Token token.Token
@@ -31,6 +37,12 @@ func (nt *NegativeIntegerType) Start() token.Position {
 
 func (nt *NegativeIntegerType) End() token.Position {
 	return nt.Pos.To(4) // length of `nint`
+}
+
+func (nt *NegativeIntegerType) String() string {
+	s := fmt.Sprintf("%s - %s", nt.Start(), nt.End())
+
+	return s
 }
 
 // IntegerLiteral represents the AST Node for an integer literal i.e 3
@@ -46,4 +58,10 @@ func (il *IntegerLiteral) Start() token.Position {
 
 func (il *IntegerLiteral) End() token.Position {
 	return il.Pos.To(len(fmt.Sprintf("%d", il.Literal)))
+}
+
+func (il *IntegerLiteral) String() string {
+	s := fmt.Sprintf("%s - %s", il.Start(), il.End())
+
+	return s
 }

--- a/ast/map.go
+++ b/ast/map.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type Map struct {
 	Pos   token.Position
@@ -17,4 +21,10 @@ func (m *Map) End() token.Position {
 		return token.Position{Offset: -1}
 	}
 	return m.Rules[len(m.Rules)-1].End()
+}
+
+func (m *Map) String() string {
+	s := fmt.Sprintf("%s - %s", m.Start(), m.End())
+
+	return s
 }

--- a/ast/node.go
+++ b/ast/node.go
@@ -2,7 +2,9 @@
 
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Node interface represents an AST Node
 type Node interface {
@@ -11,4 +13,6 @@ type Node interface {
 
 	// End returns the end token of the node
 	End() token.Position
+
+	String() string
 }

--- a/ast/null.go
+++ b/ast/null.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // NullType represents the AST Node for the `null` and `nil` tokens
 type NullType struct {
@@ -14,4 +18,10 @@ func (nt *NullType) Start() token.Position {
 
 func (nt *NullType) End() token.Position {
 	return nt.Pos.To(4) // lenth of `null`
+}
+
+func (nt *NullType) String() string {
+	s := fmt.Sprintf("%s - %s", nt.Start(), nt.End())
+
+	return s
 }

--- a/ast/occurrence.go
+++ b/ast/occurrence.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Optional represents the AST Node for the `?` prefixed optional entry
 type Optional struct {
@@ -15,6 +19,12 @@ func (i *Optional) Start() token.Position {
 
 func (i *Optional) End() token.Position {
 	return i.Item.End()
+}
+
+func (i *Optional) String() string {
+	s := fmt.Sprintf("%s - %s", i.Start(), i.End())
+
+	return s
 }
 
 func (i *Optional) groupEntry() {}
@@ -32,6 +42,12 @@ func (nm *NMOccurrence) Start() token.Position {
 
 func (nm *NMOccurrence) End() token.Position {
 	return nm.M.End()
+}
+
+func (nm *NMOccurrence) String() string {
+	s := fmt.Sprintf("%s - %s", nm.Start(), nm.End())
+
+	return s
 }
 
 func (nm *NMOccurrence) groupEntry() {}

--- a/ast/range.go
+++ b/ast/range.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Range represents the AST Node for `..` and `...` range definition tokens.
 type Range struct {
@@ -18,6 +22,12 @@ func (r *Range) Start() token.Position {
 func (r *Range) End() token.Position {
 	// Assuming token is either .. or ... the statement yields (2 + 0) or (2 +1)
 	return r.To.End()
+}
+
+func (r *Range) String() string {
+	s := fmt.Sprintf("%s - %s", r.Start(), r.End())
+
+	return s
 }
 
 func (r *Range) groupEntry() {}

--- a/ast/rule.go
+++ b/ast/rule.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // Rule represents the AST Node for typed identifer.
 // It maps the name of the type to the type
@@ -16,6 +20,12 @@ func (r *Rule) Start() token.Position {
 }
 func (r *Rule) End() token.Position {
 	return r.Value.End()
+}
+
+func (r *Rule) String() string {
+	s := fmt.Sprintf("%s - %T:%s", r.Name, r.Value, r.Value)
+
+	return s
 }
 
 func (r *Rule) ge() {}

--- a/ast/tag.go
+++ b/ast/tag.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type Tag struct {
 	Pos              token.Position
@@ -15,4 +19,10 @@ func (t *Tag) Start() token.Position {
 
 func (t *Tag) End() token.Position {
 	return t.Item.End().To(1) // add )
+}
+
+func (t *Tag) String() string {
+	s := fmt.Sprintf("%s - %s", t.Start(), t.End())
+
+	return s
 }

--- a/ast/text.go
+++ b/ast/text.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // TextLiteral represents the AST Node for a text literal
 type TextLiteral struct {
@@ -17,6 +21,12 @@ func (tl *TextLiteral) End() token.Position {
 	return tl.Pos.To(len(tl.Literal))
 }
 
+func (tl *TextLiteral) String() string {
+	s := fmt.Sprintf("%s - %s", tl.Start(), tl.End())
+
+	return s
+}
+
 // TstrType represents the AST Node for the `tstr` type definition token
 type TstrType struct {
 	Pos   token.Position
@@ -29,4 +39,10 @@ func (tt *TstrType) Start() token.Position {
 
 func (tt *TstrType) End() token.Position {
 	return tt.Pos.To(4)
+}
+
+func (tt *TstrType) String() string {
+	s := fmt.Sprintf("%s - %s", tt.Start(), tt.End())
+
+	return s
 }

--- a/ast/typechoice.go
+++ b/ast/typechoice.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // TypeChoice represents the AST Node for `/` type choice operator
 type TypeChoice struct {
@@ -15,4 +19,10 @@ func (tc *TypeChoice) Start() token.Position {
 
 func (tc *TypeChoice) End() token.Position {
 	return tc.Second.End()
+}
+
+func (tc *TypeChoice) String() string {
+	s := fmt.Sprintf("%s - %s", tc.Start(), tc.End())
+
+	return s
 }

--- a/ast/uint.go
+++ b/ast/uint.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 // UintType represents the AST Node for `uint` data definition type
 type UintType struct {
@@ -14,4 +18,9 @@ func (ut *UintType) Start() token.Position {
 
 func (ut *UintType) End() token.Position {
 	return ut.Range.End
+}
+func (ut *UintType) String() string {
+	s := fmt.Sprintf("%s - %s", ut.Start(), ut.End())
+
+	return s
 }

--- a/ast/uint_literal.go
+++ b/ast/uint_literal.go
@@ -20,3 +20,9 @@ func (ul *UintLiteral) Start() token.Position {
 func (ul *UintLiteral) End() token.Position {
 	return ul.Pos.To(len(fmt.Sprintf("%d", ul.Literal)))
 }
+
+func (ul *UintLiteral) String() string {
+	s := fmt.Sprintf("%s - %s", ul.Start(), ul.End())
+
+	return s
+}

--- a/ast/unwrap.go
+++ b/ast/unwrap.go
@@ -1,6 +1,10 @@
 package ast
 
-import "github.com/HannesKimara/cddlc/token"
+import (
+	"fmt"
+
+	"github.com/HannesKimara/cddlc/token"
+)
 
 type Unwrap struct {
 	Pos   token.Position
@@ -14,4 +18,10 @@ func (u *Unwrap) Start() token.Position {
 
 func (u *Unwrap) End() token.Position {
 	return u.Item.End()
+}
+
+func (u *Unwrap) String() string {
+	s := fmt.Sprintf("%s - %s", u.Start(), u.End())
+
+	return s
 }

--- a/cmd/cddlc/commands.go
+++ b/cmd/cddlc/commands.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"runtime"
 
@@ -19,18 +18,6 @@ const (
 	TAB = "    "
 )
 
-func readSource(filename string) (src []byte, err error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return
-	}
-	src, err = ioutil.ReadAll(f)
-	if err != nil {
-		return
-	}
-	return
-}
-
 func checkArgs(cCtx *cli.Context, n int) bool {
 	return cCtx.Args().Len() == n
 }
@@ -40,7 +27,7 @@ func LexerCmd(cCtx *cli.Context) error {
 		return errors.New("filename required")
 	}
 
-	src, err := readSource(cCtx.Args().First())
+	src, err := os.ReadFile(cCtx.Args().First())
 	if err != nil {
 		return err
 	}
@@ -69,7 +56,7 @@ func ParseCmd(cCtx *cli.Context) error {
 		return errors.New("filename required")
 	}
 
-	src, err := readSource(cCtx.Args().First())
+	src, err := os.ReadFile(cCtx.Args().First())
 	if err != nil {
 		return err
 	}

--- a/cmd/cddlc/commands/generate.go
+++ b/cmd/cddlc/commands/generate.go
@@ -68,7 +68,7 @@ func GenerateCmd(cCtx *cli.Context) error {
 		if !stat.IsDir() {
 			return errors.New("`" + build.SourceDir + "`: is not a directory")
 		}
-		files, err := ioutil.ReadDir(build.SourceDir)
+		files, err := os.ReadDir(build.SourceDir)
 		if err != nil {
 			return err
 		}
@@ -142,7 +142,7 @@ func generateFile(cCtx *cli.Context, pkgName, filepath, outPath string) error {
 	if err != nil {
 		return err
 	}
-	gen.String(out)
+
 	return nil
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -543,7 +543,7 @@ func (p *Parser) parseSizeOperator(left ast.Node) (ast.Node, errors.Diagnostic) 
 	}
 
 	switch val := left.(type) {
-	case *ast.BstrType, *ast.UintType, *ast.TstrType:
+	case *ast.BstrType, *ast.UintType, *ast.TstrType, *ast.BytesType:
 		sop.Type = val
 	default:
 		err := p.errorUnsupportedTypes(sop.Pos, p.currliteral, token.TSTR, token.BSTR, token.UINT)
@@ -704,9 +704,13 @@ func (p *Parser) parseArray() (ast.Node, errors.Diagnostic) {
 
 func (p *Parser) parseComment() (ast.Node, errors.Diagnostic) {
 	cg := &ast.CommentGroup{}
-	cg.List = append(cg.List, &ast.Comment{Pos: p.pos, Text: p.currliteral})
+	cg.List = append(cg.List, p.parseInnerComment())
 
 	for p.peekToken == token.COMMENT {
+		// If the comment is not on the next line it's a separate block.
+		if p.peekPos.Line-p.pos.Line > 1 {
+			break
+		}
 		p.next()
 		cg.List = append(cg.List, p.parseInnerComment())
 	}

--- a/transforms/codegen/golang/comment_handler.go
+++ b/transforms/codegen/golang/comment_handler.go
@@ -1,0 +1,10 @@
+package gogen
+
+// CommentHandler allows library users to define custom handling for
+// comments.
+type CommentHandler interface {
+	// Handles is called for stand-alone comments
+	HandleComment(comment string)
+	// HandleRule is called for a comment preceding a rule definition.
+	HandleRuleComment(comment string, cddlTypeName string, goTypeName string)
+}

--- a/transforms/codegen/golang/comment_handler_test.go
+++ b/transforms/codegen/golang/comment_handler_test.go
@@ -1,0 +1,67 @@
+package gogen_test
+
+import (
+	"testing"
+
+	"github.com/HannesKimara/cddlc/lexer"
+	"github.com/HannesKimara/cddlc/parser"
+	gogen "github.com/HannesKimara/cddlc/transforms/codegen/golang"
+)
+
+type testCommentHandler struct {
+	comment          string
+	ruleComment      string
+	ruleCddlTypeName string
+	ruleGoTypeName   string
+}
+
+func (h *testCommentHandler) HandleComment(comment string) {
+	h.comment = comment
+}
+
+func (h *testCommentHandler) HandleRuleComment(comment string, cddlTypeName string, goTypeName string) {
+	h.ruleComment = comment
+	h.ruleCddlTypeName = cddlTypeName
+	h.ruleGoTypeName = goTypeName
+}
+
+func TestCommentHandler(t *testing.T) {
+	gen := gogen.NewGenerator("lib")
+	h := &testCommentHandler{}
+	gen.SetCommentHandler(h)
+
+	input := `; Some header comment
+	; to my my cddl definition.
+	
+	; type key 12
+	status-message = {
+		status: text
+	}`
+
+	l := lexer.NewLexer([]byte(input))
+	p := parser.NewParser(l)
+
+	cddl, err := p.ParseFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	gen.Visit(cddl)
+
+	expectedComment := "Some header comment\nto my my cddl definition."
+	if h.comment != expectedComment {
+		t.Errorf("Expected comment %#v, got %#v", expectedComment, h.comment)
+	}
+	expectedRuleComment := "type key 12"
+	if h.ruleComment != expectedRuleComment {
+		t.Errorf("Expected rule comment %#v, got %#v", expectedRuleComment, h.ruleComment)
+	}
+	expectedRuleCddlTypeName := "status-message"
+	if h.ruleCddlTypeName != expectedRuleCddlTypeName {
+		t.Errorf("Expected rule CDDL type name %#v, got %#v", expectedRuleCddlTypeName, h.ruleCddlTypeName)
+	}
+	expectedRuleGoTypeName := "StatusMessage"
+	if h.ruleGoTypeName != expectedRuleGoTypeName {
+		t.Errorf("Expected rule Go type name %#v, got %#v", expectedRuleGoTypeName, h.ruleGoTypeName)
+	}
+}

--- a/transforms/codegen/golang/gen_base_types.go
+++ b/transforms/codegen/golang/gen_base_types.go
@@ -6,6 +6,14 @@ import (
 	"github.com/HannesKimara/cddlc/ast"
 )
 
+type Architecture uint
+
+const (
+	ArchitectureGeneric Architecture = iota + 1
+	Architecture32
+	Architecture64
+)
+
 func (g *Generator) transpileTstrType(tstr *ast.TstrType) *gast.Ident {
 	return &gast.Ident{
 		Name: "string",
@@ -27,19 +35,46 @@ func (g *Generator) transpileNullType(nt *ast.NullType) *gast.Ident {
 }
 
 func (g *Generator) transpileIntegerType(it *ast.IntegerType) *gast.Ident {
+	name := "int"
+	switch g.architecture {
+	case Architecture32:
+		name = "int32"
+	case Architecture64:
+		name = "int64"
+	}
 	return &gast.Ident{
-		Name: "int",
+		Name: name,
 	}
 }
 
 func (g *Generator) transpileUintType(it *ast.UintType) *gast.Ident {
+	name := "uint"
+	switch g.architecture {
+	case Architecture32:
+		name = "uint32"
+	case Architecture64:
+		name = "uint64"
+	}
 	return &gast.Ident{
-		Name: "uint",
+		Name: name,
 	}
 }
 
 func (g *Generator) transpileBoolType(bt *ast.BooleanType) *gast.Ident {
 	return &gast.Ident{
 		Name: "bool",
+	}
+}
+
+func (g *Generator) transpileFloatType(fl *ast.FloatType) *gast.Ident {
+	name := "float64"
+	switch g.architecture {
+	case Architecture32:
+		name = "float32"
+	case Architecture64:
+		name = "float64"
+	}
+	return &gast.Ident{
+		Name: name,
 	}
 }

--- a/transforms/codegen/golang/gen_grouped.go
+++ b/transforms/codegen/golang/gen_grouped.go
@@ -4,73 +4,221 @@ import (
 	"errors"
 	"fmt"
 	gast "go/ast"
-	"go/token"
-	"log"
+	gtoken "go/token"
+	"strconv"
 	"strings"
 
 	"github.com/HannesKimara/cddlc/ast"
+	"github.com/iancoleman/strcase"
 )
+
+type outputType uint
+
+const (
+	outputTypeLiteral = iota
+	outputTypeTypeDef
+	outputTypeEnum
+	outputTypeStruct
+)
+
+func (g *Generator) isChoiceGroup(group *ast.Group) bool {
+	if len(group.Entries) > 0 {
+		if entry, ok := group.Entries[0].(*ast.Entry); ok {
+			if _, ok := entry.Value.(*ast.IntegerLiteral); ok {
+				// This is a group used as a choice.
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *Generator) handleRuleComment(cddlTypeName string, goTypeName string) {
+	if g.lastRootComment == nil {
+		return
+	}
+	if g.commentHandler != nil {
+		g.commentHandler.HandleRuleComment(strings.TrimSpace(g.lastRootComment.Text), cddlTypeName, goTypeName)
+	}
+
+	g.lastRootComment = nil
+}
 
 func (g *Generator) Visit(node ast.Node) *Generator {
 	switch val := node.(type) {
+	case *ast.CommentGroup:
+		if g.lastRootComment != nil && g.commentHandler != nil {
+			g.commentHandler.HandleComment(strings.TrimSpace(g.lastRootComment.Text))
+		}
+
+		comments := []string{}
+		for _, comment := range val.List {
+			comments = append(comments, strings.TrimSpace(comment.Text))
+		}
+		g.lastRootComment = &ast.Comment{Text: strings.Join(comments, "\n")}
+
+	case *ast.Comment:
+		if g.lastRootComment != nil && g.commentHandler != nil {
+			g.commentHandler.HandleComment(strings.TrimSpace(g.lastRootComment.Text))
+		}
+		g.lastRootComment = val
+
 	case *ast.Rule:
-		var decl gast.Decl
-		var outExpr gast.Expr
-		var declToken token.Token
-		var specs []gast.Spec
-
-		stct, err := g.transpileNode(val.Value)
-		if err != nil {
-			panic(err)
-		}
-		if v, ok := stct.node.(gast.Expr); !ok {
-			panic(fmt.Sprintf("unexpected transpilation product for source %s - %s (%T)", val.Start(), val.End(), stct.node))
-		} else {
-			outExpr = v
-		}
-
+		var outType outputType
 		switch val.Value.(type) {
-
 		case *ast.BooleanLiteral, *ast.FloatLiteral, *ast.IntegerLiteral, *ast.TextLiteral, *ast.UintLiteral:
-			declToken = token.VAR
-			specs = []gast.Spec{
-				&gast.ValueSpec{
-					Names:  []*gast.Ident{g.transpileIdentifier(val.Name)},
-					Values: []gast.Expr{outExpr},
+			outType = outputTypeLiteral
+		case *ast.UintType, *ast.IntegerType, *ast.FloatType:
+			outType = outputTypeTypeDef
+		case *ast.Enumeration:
+			outType = outputTypeEnum
+		case *ast.Map, *ast.Array:
+			outType = outputTypeStruct
+		case *ast.Group:
+			outType = outputTypeStruct
+			if group, ok := val.Value.(*ast.Group); ok {
+				if g.isChoiceGroup(group) {
+					// This is a group used as a choice.
+					outType = outputTypeEnum
+				}
+			}
+		}
+
+		switch outType {
+		case outputTypeLiteral:
+			stct, err := g.transpileNode(val.Value)
+			if err != nil {
+				panic(err)
+			}
+			name := g.transpileIdentifier(val.Name, nil)
+			g.handleRuleComment(val.Name.Name, name.Name)
+
+			expr, ok := stct.node.(gast.Expr)
+			if !ok {
+				panic(fmt.Sprintf("unexpected transpilation product for source %s - %s (%T)", val.Start(), val.End(), stct.node))
+			}
+
+			decl := &gast.GenDecl{
+				Tok: gtoken.VAR,
+				Specs: []gast.Spec{
+					&gast.ValueSpec{
+						Names:  []*gast.Ident{name},
+						Values: []gast.Expr{expr},
+					},
 				},
+				Doc: &gast.CommentGroup{
+					List: []*gast.Comment{{Text: "\n// (cddlc) Ident: " + val.Name.Name + "\n"}},
+				},
+			}
+			g.appendDecl(decl)
+
+		case outputTypeTypeDef:
+			name := g.transpileIdentifier(val.Name, nil)
+			g.handleRuleComment(val.Name.Name, name.Name)
+			typ, err := g.transpileNode(val.Value)
+			if err != nil {
+				panic(fmt.Sprintf("unexpected type for source %s - %s (%T)", val.Start(), val.End(), val.Value))
+			}
+			decl := &gast.GenDecl{
+				Tok: gtoken.TYPE,
+				Specs: []gast.Spec{
+					&gast.TypeSpec{
+						Name: name,
+						Type: typ.node.(*gast.Ident),
+					},
+				},
+				Doc: &gast.CommentGroup{
+					List: []*gast.Comment{{Text: "\n// (cddlc) Ident: " + val.Name.Name + "\n"}},
+				},
+			}
+			g.appendDecl(decl)
+
+		case outputTypeEnum: // Enumeration (& choice group)
+			g.currentGroupName = strcase.ToCamel(val.Name.Name)
+			g.currentGroupType = ast.GroupTypeEnum
+			g.outputEnum(val.Name, val.Value)
+			g.handleRuleComment("", val.Name.Name)
+
+		case outputTypeStruct: // Map, Group & Array
+			g.currentGroupName = strcase.ToCamel(val.Name.Name)
+			g.currentGroupType = ast.GroupTypeStruct
+
+			stct, err := g.transpileNode(val.Value)
+			if err != nil {
+				panic(err)
+			}
+			name := g.transpileIdentifier(val.Name, nil)
+			g.handleRuleComment(val.Name.Name, name.Name)
+
+			typeExpr, ok := stct.node.(gast.Expr)
+			if !ok {
+				panic(fmt.Sprintf("unexpected transpilation product for source %s - %s (%T)", val.Start(), val.End(), stct.node))
+			}
+
+			decl := &gast.GenDecl{
+				Tok: gtoken.TYPE,
+				Specs: []gast.Spec{
+					&gast.TypeSpec{
+						Name: name,
+						Type: typeExpr,
+					},
+				},
+				Doc: &gast.CommentGroup{
+					List: []*gast.Comment{{Text: "\n// (cddlc) Ident: " + val.Name.Name + "\n"}},
+				},
+			}
+			g.appendDecl(decl)
+
+			if g.withValidators {
+				valDecl := g.bundleValidators(stct.validators, val)
+				g.file.Decls = append(g.file.Decls, valDecl)
 			}
 
 		default:
-			declToken = token.TYPE
-			specs = []gast.Spec{
-				&gast.TypeSpec{
-					Name: g.transpileIdentifier(val.Name),
-					Type: outExpr,
-				},
-			}
-			// panic(fmt.Sprintf("unexpected type %+v", val.Value))
+			panic(fmt.Sprintf("unexpected type %+v", val.Value))
 		}
 
-		decl = &gast.GenDecl{
-			Tok:   declToken,
-			Specs: specs,
-			Doc:   &gast.CommentGroup{List: []*gast.Comment{{Text: "\n// (cddlc) Ident: " + val.Name.Name + "\n"}}},
-		}
-
-		// stct.spec = decl
-		g.file.Decls = append(g.file.Decls, decl)
-
-		log.Println("Len("+val.Name.Name+"): ", len(stct.validators))
-
-		valDecl := g.bundleValidators(stct.validators, val)
-		g.file.Decls = append(g.file.Decls, valDecl)
 	case *ast.CDDL:
 		for _, rule := range val.Rules {
 			g.Visit(rule)
 		}
+
+	default:
+		fmt.Printf("Skipping node %T", node)
 	}
 
 	return g
+}
+
+func (g *Generator) outputEnum(eName *ast.Identifier, eValue ast.Node) gast.Expr {
+	// Enum type
+	name := g.transpileIdentifier(eName, nil)
+	decl := &gast.GenDecl{
+		Tok: gtoken.TYPE,
+		Specs: []gast.Spec{
+			&gast.TypeSpec{
+				Name: name,
+				Type: g.transpileUintType(nil),
+			},
+		},
+		Doc: &gast.CommentGroup{
+			List: []*gast.Comment{{Text: "\n// (cddlc) Ident: " + name.Name + "\n"}},
+		},
+	}
+	g.appendDecl(decl)
+
+	stct, err := g.transpileEnumerationValue(eValue)
+	if err != nil {
+		panic(err)
+	}
+
+	valuesDecl, ok := stct.node.(*gast.GenDecl)
+	if !ok {
+		panic(fmt.Sprintf("unexpected transpilation product for source %s - %s (%T)", eValue.Start(), eValue.End(), stct.node))
+	}
+	g.appendDecl(valuesDecl)
+
+	return name
 }
 
 func (g *Generator) bundleValidators(validators []gast.CallExpr, rule *ast.Rule) *gast.FuncDecl {
@@ -90,7 +238,7 @@ func (g *Generator) bundleValidators(validators []gast.CallExpr, rule *ast.Rule)
 					selfIdent,
 				},
 				Type: &gast.StarExpr{
-					X: gast.NewIdent(g.transpileIdentifier(rule.Name).String()),
+					X: gast.NewIdent(g.transpileIdentifier(rule.Name, nil).String()),
 				},
 			}},
 		},
@@ -147,14 +295,23 @@ func (g *Generator) transpileGroupLike(entries []ast.GroupEntry) (*structure, er
 				return nil, err
 			}
 			if cast, ok := stct.node.(*gast.Field); ok {
-				cast.Tag = &gast.BasicLit{Kind: token.STRING, Value: "`cbor:\",omitempty\"`"}
+				typ := cast.Type
+				if _, ok := cast.Type.(*gast.ArrayType); !ok {
+					cast.Type = &gast.StarExpr{
+						X: typ,
+					}
+				}
+				tag := cast.Tag.Value
+				if len(tag) > 3 {
+					cast.Tag.Value = tag[:len(tag)-2] + ",omitempty" + tag[len(tag)-2:]
+				}
 				field = cast
 			} else {
 				return nil, err
 			}
 		case *ast.Identifier:
 			field = &gast.Field{
-				Type: g.transpileIdentifier(val),
+				Type: g.transpileIdentifier(val, nil),
 			}
 		case *ast.NMOccurrence:
 			field = &gast.Field{
@@ -171,57 +328,206 @@ func (g *Generator) transpileGroupLike(entries []ast.GroupEntry) (*structure, er
 }
 
 func (g *Generator) transpileGroup(group *ast.Group) (*structure, error) {
-	fl, err := g.transpileGroupLike(group.Entries)
+	var ret *structure
+	switch g.currentGroupType {
+	case ast.GroupTypeStruct:
+		fl, err := g.transpileGroupLike(group.Entries)
+		if err != nil {
+			return nil, err
+		}
 
-	if err != nil {
-		return fl, err
+		st := &gast.StructType{Fields: fl.node.(*gast.FieldList)}
+		ret = newStructure(st)
+		ret.Embed(fl)
+
+	case ast.GroupTypeEnum:
+		specs := []gast.Spec{}
+		for _, entry := range group.Entries {
+			var spec *gast.ValueSpec
+			switch val := entry.(type) {
+			case *ast.Entry:
+				spec = &gast.ValueSpec{
+					Names: []*gast.Ident{
+						gast.NewIdent(g.currentGroupName + strcase.ToCamel(val.Name.Name)),
+					},
+					Type: g.formatIdentifier(g.currentGroupName, nil),
+					Values: []gast.Expr{
+						&gast.BasicLit{
+							Kind:  gtoken.INT,
+							Value: strconv.FormatInt(val.Value.(*ast.IntegerLiteral).Literal, 10),
+						},
+					},
+				}
+
+			default:
+				panic(fmt.Sprintf("What was that? %T: `%+v`", val, val))
+			}
+
+			specs = append(specs, spec)
+		}
+
+		ret = newStructure(&gast.GenDecl{
+			Tok:   gtoken.CONST,
+			Specs: specs,
+		})
 	}
-
-	st := &gast.StructType{Fields: fl.node.(*gast.FieldList)}
-	ret := newStructure(st)
-	ret.Embed(fl)
 
 	return ret, nil
 }
 
 func (g *Generator) transpileArray(arr *ast.Array) (*structure, error) {
-	fl := &gast.FieldList{}
-	fl.List = append(fl.List, &gast.Field{
-		Names: []*gast.Ident{gast.NewIdent("_")},
-		Type: &gast.StructType{
-			Fields: &gast.FieldList{},
-		},
-		Tag: &gast.BasicLit{Kind: token.STRING, Value: "`cbor:\",toarray\"`"},
-	})
+	if len(arr.Rules) == 1 {
+		if mn, ok := arr.Rules[0].(*ast.NMOccurrence); ok {
+			return newStructure(g.transpileNMOccurence(mn)), nil
+		}
+	}
 
-	fl2, err := g.transpileGroupLike(arr.Rules)
+	// fxamacker/cbor way to indicate encoding without field names:
+	// _ struct{} `cbor:",toarray"`
+	// TODO: make customizable since other libraries have different convention.
+	// E.g.: ugorji/go/codec style:
+	// _struct bool    `codec:",toarray"`
+	fieldList := &gast.FieldList{
+		List: []*gast.Field{{
+			Names: []*gast.Ident{gast.NewIdent("_")},
+			Type: &gast.StructType{
+				Fields: &gast.FieldList{},
+			},
+			Tag: &gast.BasicLit{Kind: gtoken.STRING, Value: "`cbor:\",toarray\"`"},
+		}},
+	}
+
+	groupFieldList, err := g.transpileGroupLike(arr.Rules)
 	if err != nil {
 		return nil, err
 	}
 
-	fl.List = append(fl.List, fl2.node.(*gast.FieldList).List...)
+	fieldList.List = append(fieldList.List, groupFieldList.node.(*gast.FieldList).List...)
+	return newStructure(&gast.StructType{Fields: fieldList}), nil
+}
+
+func (g *Generator) transpileMap(m *ast.Map) (*structure, error) {
+	fl := &gast.FieldList{}
+	for _, rule := range m.Rules {
+		var field *gast.Field
+		switch val := rule.(type) {
+		case *ast.Entry:
+			stct, err := g.transpileEntry(val)
+			if err != nil {
+				panic(err)
+			}
+			field = stct.node.(*gast.Field)
+		case *ast.Optional:
+			stct, err := g.transpileNode(val.Item)
+			if err != nil {
+				return nil, err
+			}
+			if cast, ok := stct.node.(*gast.Field); ok {
+				typ := cast.Type
+				if _, ok := cast.Type.(*gast.ArrayType); !ok {
+					cast.Type = &gast.StarExpr{
+						X: typ,
+					}
+				}
+				tag := cast.Tag.Value
+				if len(tag) > 3 {
+					cast.Tag.Value = tag[:len(tag)-2] + ",omitempty" + tag[len(tag)-2:]
+				}
+				field = cast
+			} else {
+				return nil, err
+			}
+		case *ast.Identifier:
+			field = &gast.Field{
+				Type: g.transpileIdentifier(val, nil),
+			}
+		default:
+			panic(fmt.Sprintf("What was that? %T: `%+v`", val, val))
+		}
+		fl.List = append(fl.List, field)
+	}
+
 	return newStructure(&gast.StructType{Fields: fl}), nil
 }
 
-func (g *Generator) transpileEntry(entry *ast.Entry) (*structure, error) {
-	ident := g.transpileIdentifier(entry.Name)
-	stct, err := g.transpileNode(entry.Value)
+func (g *Generator) transpileEnumeration(e *ast.Enumeration) (*structure, error) {
+	return g.transpileEnumerationValue(e.Value)
+}
 
-	if err != nil {
-		return nil, err
+func (g *Generator) transpileEnumerationValue(eValue ast.Node) (*structure, error) {
+	return g.transpileNode(eValue)
+}
+
+func (g *Generator) transpileInlineEnumeration(name string, e *ast.Enumeration) (*structure, error) {
+	outerGroupType := g.currentGroupType
+	outerGroupName := g.currentGroupName
+	defer func() {
+		g.currentGroupType = outerGroupType
+		g.currentGroupName = outerGroupName
+	}()
+	g.currentGroupType = ast.GroupTypeEnum
+	g.currentGroupName = name
+
+	eName := &ast.Identifier{
+		Name: name,
+	}
+	return newStructure(g.outputEnum(eName, e.Value)), nil
+}
+
+func (g *Generator) tagPartWithLabel(label, value string) string {
+	return fmt.Sprintf(`%s:"%s"`, label, value)
+}
+func (g *Generator) combineTags(parts []string) string {
+	tag := strings.Join(parts, ",")
+	return fmt.Sprintf("`%s`", tag)
+}
+
+func (g *Generator) isInlineEnumeration(e *ast.Enumeration) bool {
+	if _, ok := e.Value.(*ast.Group); ok {
+		return true
+	}
+	return false
+}
+
+func (g *Generator) transpileEntry(entry *ast.Entry) (*structure, error) {
+	fieldName := g.transpileIdentifier(entry.Name, entry.TrailingComment)
+
+	var typeExpr gast.Expr
+	if e, ok := entry.Value.(*ast.Enumeration); ok && g.isInlineEnumeration(e) {
+		inlineName := strcase.ToCamel(g.currentGroupName + "-" + fieldName.Name)
+		stct, err := g.transpileInlineEnumeration(inlineName, e)
+		if err != nil {
+			return nil, err
+		}
+		typeExpr = stct.node.(gast.Expr)
+	} else {
+		stct, err := g.transpileNode(entry.Value)
+		if err != nil {
+			return nil, err
+		}
+		typeExpr = stct.node.(gast.Expr)
 	}
 
+	tag := g.combineTags(
+		[]string{
+			g.tagPartWithLabel(g.fieldTagName, entry.Name.Name),
+		},
+	)
 	field := &gast.Field{
-		Names: []*gast.Ident{ident},
-		Type:  stct.node.(gast.Expr),
+		Names: []*gast.Ident{fieldName},
+		Type:  typeExpr,
+		Tag:   &gast.BasicLit{Kind: gtoken.STRING, Value: tag},
 	}
 
 	stctRet := newStructure(field)
-
-	log.Println("Embed called")
-	stctRet.Embed(stct)
+	// stctRet.Embed(stct)
 
 	return stctRet, nil
+}
+
+func (g *Generator) transpileTypeChoice(c *ast.TypeChoice) (*structure, error) {
+	g.currentGroupType = outputTypeEnum
+	return g.transpileNode(c.First)
 }
 
 func (g *Generator) transpileNode(node ast.Node) (*structure, error) {
@@ -233,12 +539,18 @@ func (g *Generator) transpileNode(node ast.Node) (*structure, error) {
 		return g.transpileGroup(val)
 	case *ast.Array:
 		return g.transpileArray(val)
+	case *ast.Map:
+		return g.transpileMap(val)
+	case *ast.Enumeration:
+		return g.transpileEnumeration(val)
 	case *ast.Entry:
 		return g.transpileEntry(val)
+	case *ast.TypeChoice:
+		return g.transpileTypeChoice(val)
 	case *ast.BooleanType:
 		return newStructure(g.transpileBoolType(val)), nil
 	case *ast.Identifier:
-		return newStructure(g.transpileIdentifier(val)), nil
+		return newStructure(g.transpileIdentifier(val, nil)), nil
 	case *ast.TstrType:
 		return newStructure(g.transpileTstrType(val)), nil
 	case *ast.BytesType:
@@ -249,6 +561,8 @@ func (g *Generator) transpileNode(node ast.Node) (*structure, error) {
 		return newStructure(g.transpileNullType(val)), nil
 	case *ast.IntegerType:
 		return newStructure(g.transpileIntegerType(val)), nil
+	case *ast.FloatType:
+		return newStructure(g.transpileFloatType(val)), nil
 	case *ast.UintType:
 		return newStructure(g.transpileUintType(val)), nil
 	case *ast.IntegerLiteral:
@@ -264,6 +578,6 @@ func (g *Generator) transpileNode(node ast.Node) (*structure, error) {
 	case *ast.SizeOperatorControl:
 		return g.transformSizeOp(val)
 	default:
-		panic(fmt.Sprintf("unexpected type %T", val))
+		panic(fmt.Sprintf("unexpected type %T: %s", val, val))
 	}
 }

--- a/transforms/codegen/golang/gen_identifiers.go
+++ b/transforms/codegen/golang/gen_identifiers.go
@@ -15,25 +15,40 @@ type stringConverter func(string) string
 
 var converters map[string]stringConverter
 
-func (g *Generator) transpileIdentifier(ident *ast.Identifier) *gast.Ident {
-	formatted := strcase.ToCamel(ident.Name)
-
-	if ident.IsSocket() || ident.IsPlug() {
-		formatted = strings.TrimLeft(ident.Name, "$")
-	}
+func (g *Generator) formatIdentifier(name string, trailingComment *ast.Comment) *gast.Ident {
+	formatted := strcase.ToCamel(name)
 
 	if token.IsIdentifier(formatted) {
-		return &gast.Ident{
-			Name: formatted,
+		formatted = g.identifierPrefix + formatted
+	} else {
+		_, err := strconv.ParseInt(formatted, 0, 64)
+		if err != nil {
+			panic(fmt.Sprintf("Identifier %s -> %s could not be transformed to valid go identifier", name, formatted))
 		}
+
+		formatted = "IntKey_" + formatted
 	}
-	_, err := strconv.ParseInt(formatted, 0, 64)
-	if err != nil {
-		panic(fmt.Sprintf("Identifier %s -> %s could not be transformed to valid go identifier", ident.Name, formatted))
+
+	if g.customIdentifierFormatter != nil {
+		comment := ""
+		if trailingComment != nil {
+			comment = strings.TrimSpace(trailingComment.Text)
+		}
+		formatted = g.customIdentifierFormatter(name, comment, formatted)
 	}
+
 	return &gast.Ident{
-		Name: "IntKey_" + formatted,
+		Name: formatted,
 	}
+}
+
+func (g *Generator) transpileIdentifier(ident *ast.Identifier, trailingComment *ast.Comment) *gast.Ident {
+	name := ident.Name
+	if ident.IsSocket() || ident.IsPlug() {
+		name = strings.TrimLeft(ident.Name, "$")
+	}
+
+	return g.formatIdentifier(name, trailingComment)
 }
 
 func init() {

--- a/transforms/codegen/golang/gen_operator.go
+++ b/transforms/codegen/golang/gen_operator.go
@@ -38,7 +38,9 @@ func (g *Generator) transformSizeOp(op *ast.SizeOperatorControl) (*structure, er
 	default:
 		panic("fix later")
 	}
-	g.addImport(VALIDATOR_PKG, "")
+	if g.withValidators {
+		g.addImport(VALIDATOR_PKG, "")
+	}
 
 	log.Println("Len validators: ", len(stct.validators))
 

--- a/transforms/codegen/golang/gen_test.go
+++ b/transforms/codegen/golang/gen_test.go
@@ -1,19 +1,120 @@
 package gogen_test
 
 import (
+	"bytes"
+	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/HannesKimara/cddlc/lexer"
 	"github.com/HannesKimara/cddlc/parser"
 	gogen "github.com/HannesKimara/cddlc/transforms/codegen/golang"
+	"github.com/iancoleman/strcase"
+)
+
+const (
+	TEST_PATH = "./test-cases"
 )
 
 func TestGen(t *testing.T) {
 	gen := gogen.NewGenerator("lib")
+	gen.SetWithValidators(false)
 
-	src := `person = [name: tstr, age: uint]`
-	l := lexer.NewLexer([]byte(src))
+	tt := []struct {
+		name      string
+		input     string
+		expected  string
+		generator *gogen.Generator
+	}{
+		{
+			name:     "var",
+			input:    `attire = "bow tie"`,
+			expected: "package lib\n\n// (cddlc) Ident: attire\nvar Attire = bow tie\n",
+		},
+		{
+			name:     "type definition",
+			input:    `request-id = uint`,
+			expected: "package lib\n\n// (cddlc) Ident: request-id\ntype RequestId uint\n",
+		},
+		{
+			name: "structs",
+		},
+		{
+			name: "enum",
+		},
+	}
+
+	for _, tc := range tt {
+		t.Run(tc.name, func(t *testing.T) {
+			input := tc.input
+			expected := tc.expected
+			if len(tc.input) == 0 {
+				input, expected = mustLoadTestCase(tc.name, t)
+			}
+
+			l := lexer.NewLexer([]byte(input))
+			p := parser.NewParser(l)
+
+			cddl, err := p.ParseFile()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gen.Visit(cddl)
+
+			buf := bytes.NewBuffer(nil)
+			gen.String(buf)
+			actual := buf.String()
+			if actual != expected {
+				fmt.Printf("expected:\n%s\ngot:\n%s\n", expected, actual)
+				t.Fatalf("expected:\n%#v\ngot:\n%#v", expected, actual)
+			}
+
+			gen.Reset()
+		})
+	}
+}
+
+func mustLoadTestCase(name string, t *testing.T) (input, expected string) {
+	input = mustLoadFile(name+".cddl", t)
+	expected = mustLoadFile(name+".expected", t)
+	return
+}
+
+func mustLoadFile(name string, t *testing.T) string {
+	buf, err := os.ReadFile(filepath.Join(TEST_PATH, name))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Windows newlines
+	buf = bytes.ReplaceAll(buf, []byte("\r\n"), []byte("\n"))
+
+	return string(buf)
+}
+
+func TestIdentifierFormatter(t *testing.T) {
+	gen := gogen.NewGenerator("lib")
+	gen.SetWithValidators(false)
+
+	// Usage example: integer keys have meaning in the trailing comments that
+	// is useful as struct field names.
+	gen.SetIdentifierFormatter(func(_ string, trailingComment string, suggestion string) string {
+		name := suggestion
+
+		if len(trailingComment) > 0 {
+			name = strcase.ToCamel(trailingComment)
+		}
+
+		return name
+	})
+	input := `status-message = {
+		0: text ; status
+	}`
+	expected := "package lib\n\n// (cddlc) Ident: status-message\ntype StatusMessage struct {\n\tStatus string `cbor:\"0\"`\n}\n"
+
+	l := lexer.NewLexer([]byte(input))
 	p := parser.NewParser(l)
 
 	cddl, err := p.ParseFile()
@@ -22,5 +123,12 @@ func TestGen(t *testing.T) {
 	}
 
 	gen.Visit(cddl)
-	gen.String(os.Stdout)
+
+	buf := bytes.NewBuffer(nil)
+	gen.String(buf)
+	actual := buf.String()
+	if actual != expected {
+		fmt.Printf("expected:\n%s\ngot:\n%s\n", expected, actual)
+		t.Fatalf("expected:\n%#v\ngot:\n%#v", expected, actual)
+	}
 }

--- a/transforms/codegen/golang/test-cases/enum.cddl
+++ b/transforms/codegen/golang/test-cases/enum.cddl
@@ -1,0 +1,13 @@
+auth-status = &(
+  authenticated: 0
+  unknown-error: 1
+  timeout: 2
+)
+
+close-event = {
+  connection-id: uint
+  reason: &(
+    close-method-called: 1
+    unrecoverable-error: 100
+  )
+}

--- a/transforms/codegen/golang/test-cases/enum.expected
+++ b/transforms/codegen/golang/test-cases/enum.expected
@@ -1,0 +1,24 @@
+package lib
+
+// (cddlc) Ident: AuthStatus
+type AuthStatus uint
+
+const (
+	AuthStatusAuthenticated AuthStatus = 0
+	AuthStatusUnknownError  AuthStatus = 1
+	AuthStatusTimeout       AuthStatus = 2
+)
+
+// (cddlc) Ident: CloseEventReason
+type CloseEventReason uint
+
+const (
+	CloseEventReasonCloseMethodCalled  CloseEventReason = 1
+	CloseEventReasonUnrecoverableError CloseEventReason = 100
+)
+
+// (cddlc) Ident: close-event
+type CloseEvent struct {
+	ConnectionId uint             `cbor:"connection-id"`
+	Reason       CloseEventReason `cbor:"reason"`
+}

--- a/transforms/codegen/golang/test-cases/structs.cddl
+++ b/transforms/codegen/golang/test-cases/structs.cddl
@@ -1,0 +1,42 @@
+person = [name: tstr, age: uint]
+
+pii = (
+    age: int,
+    name: tstr,
+    employer: tstr,
+)
+
+employee = (
+    ? pii: pii
+)
+
+dog = {
+    0: int, ; age
+    1: tstr ; name
+    2: float ; leash-length
+}
+
+response = (
+  request-id: int
+)
+
+device-capability = &(
+  receive-audio: 1
+  receive-video: 2
+)
+
+content = {
+    url: text
+}
+
+device-info = {
+  response
+  display-name: text
+  state: {
+    power: bool
+    standby: bool
+  }
+  capabilities: [* device-capability]
+  secret: bytes .size 64
+  ? now-playing: {content}
+}

--- a/transforms/codegen/golang/test-cases/structs.expected
+++ b/transforms/codegen/golang/test-cases/structs.expected
@@ -1,0 +1,61 @@
+package lib
+
+// (cddlc) Ident: person
+type Person struct {
+	_ struct {
+	} `cbor:",toarray"`
+	Name string `cbor:"name"`
+	Age  uint   `cbor:"age"`
+}
+
+// (cddlc) Ident: pii
+type Pii struct {
+	Age      int    `cbor:"age"`
+	Name     string `cbor:"name"`
+	Employer string `cbor:"employer"`
+}
+
+// (cddlc) Ident: employee
+type Employee struct {
+	Pii *Pii `cbor:"pii,omitempty"`
+}
+
+// (cddlc) Ident: dog
+type Dog struct {
+	IntKey_0 int     `cbor:"0"`
+	IntKey_1 string  `cbor:"1"`
+	IntKey_2 float64 `cbor:"2"`
+}
+
+// (cddlc) Ident: response
+type Response struct {
+	RequestId int `cbor:"request-id"`
+}
+
+// (cddlc) Ident: DeviceCapability
+type DeviceCapability uint
+
+const (
+	DeviceCapabilityReceiveAudio DeviceCapability = 1
+	DeviceCapabilityReceiveVideo DeviceCapability = 2
+)
+
+// (cddlc) Ident: content
+type Content struct {
+	Url string `cbor:"url"`
+}
+
+// (cddlc) Ident: device-info
+type DeviceInfo struct {
+	Response
+	DisplayName string `cbor:"display-name"`
+	State       struct {
+		Power   bool `cbor:"power"`
+		Standby bool `cbor:"standby"`
+	} `cbor:"state"`
+	Capabilities []DeviceCapability `cbor:"capabilities"`
+	Secret       []byte             `cbor:"secret"`
+	NowPlaying   *struct {
+		Content
+	} `cbor:"now-playing,omitempty"`
+}


### PR DESCRIPTION
As mentioned in #8 this PR adds support for structs & enums. I needed a couple of out-of-spec things to get an ergonomic result for [my file](https://github.com/w3c/openscreenprotocol/blob/main/messages_appendix.cddl), I tried to create generic abstractions to support those needs as a library user:
* _Architecture_: allows you to choose between generating `int`, `int32`, `int64` etc.
* _IdentifierPrefix_: Allows you to prefix all types, this is handy when the code needs to live in a larger repo.
* _FieldTagName_: allows you to choose the name of the struct tag. For example I need `codec` for [ugorji/go/codec](https://pkg.go.dev/github.com/ugorji/go/codec).
* _IdentifierFormatter_: Allows you to override identifier formatting. In my case the CDDL file uses integer keys but I can generate better names using the trailing comments.
* _CommentHandler_: allows you to provide custom handling for comments. This allows me to gather the `type key` from my file.

Hopefully the result isn't overly opinionated.

I'm sorry for the big PR but I probably won't find the time to land it in smaller chunks. Happy to address concerns though.

closes #8